### PR TITLE
Statisk path for resurser

### DIFF
--- a/UKMnettverket.php
+++ b/UKMnettverket.php
@@ -180,15 +180,15 @@ class UKMnettverket extends Modul
 
         wp_enqueue_style(
             'UKMnettverket_arrangement_css',
-            PLUGIN_PATH . 'UKMnettverket/UKMnettverket.css'
+            plugin_dir_url(__FILE__) . 'UKMnettverket.css'
         );
         wp_enqueue_script(
             'UKMnettverket_arrangement',
-            PLUGIN_PATH . 'UKMnettverket/js/arrangement.js?v=2021-01-13'
+            plugin_dir_url(__FILE__) . 'js/arrangement.js?v=2021-01-13'
         );
         wp_enqueue_script(
             'UKMnettverket_administratorer',
-            PLUGIN_PATH . 'UKMnettverket/js/administratorer.js'
+            plugin_dir_url(__FILE__) . 'js/administratorer.js'
         );
     }
 

--- a/UKMnettverket.php
+++ b/UKMnettverket.php
@@ -180,15 +180,15 @@ class UKMnettverket extends Modul
 
         wp_enqueue_style(
             'UKMnettverket_arrangement_css',
-            plugin_dir_url(__FILE__) . 'UKMnettverket.css'
+            PLUGIN_PATH . 'UKMnettverket/UKMnettverket.css'
         );
         wp_enqueue_script(
             'UKMnettverket_arrangement',
-            plugin_dir_url(__FILE__) . 'js/arrangement.js?v=2021-01-13'
+            PLUGIN_PATH . 'UKMnettverket/js/arrangement.js?v=2021-01-13'
         );
         wp_enqueue_script(
             'UKMnettverket_administratorer',
-            plugin_dir_url(__FILE__) . 'js/administratorer.js'
+            PLUGIN_PATH . 'UKMnettverket/js/administratorer.js'
         );
     }
 

--- a/UKMnettverket.php
+++ b/UKMnettverket.php
@@ -180,15 +180,15 @@ class UKMnettverket extends Modul
 
         wp_enqueue_style(
             'UKMnettverket_arrangement_css',
-            plugin_dir_url(__FILE__) . 'UKMnettverket.css'
+            static::getPluginUrl() . 'UKMnettverket.css'
         );
         wp_enqueue_script(
             'UKMnettverket_arrangement',
-            plugin_dir_url(__FILE__) . 'js/arrangement.js?v=2021-01-13'
+            static::getPluginUrl() . 'js/arrangement.js?v=2021-01-13'
         );
         wp_enqueue_script(
             'UKMnettverket_administratorer',
-            plugin_dir_url(__FILE__) . 'js/administratorer.js'
+            static::getPluginUrl() . 'js/administratorer.js'
         );
     }
 


### PR DESCRIPTION
Bruker en final variable for å definere statisk path-en for å peke på resurser.

Deriverer fra: https://github.com/UKMNorge/UKMresources/issues/3

OBS: UKMconfig.inc.php er modifisert. Denne linjen er lagt til:
"# RESOURCES PLUGIN PATH
define('PLUGIN_PATH', 'https://' . UKM_HOSTNAME . '/wp-content/plugins/');"