### PR TITLE
URL length basert på kommuner og arrangement navn

### DIFF
--- a/twig/arrangement-add.html.twig
+++ b/twig/arrangement-add.html.twig
@@ -41,16 +41,33 @@
     jQuery(document).on('keyup', '#arrangement_navn', function() {
         // Kommunen arrangerer sammen med andre: lag liste av kommunenavn
         if (jQuery('#omrade_type').val() == 'kommune' && jQuery('#radioButtonValue_sammen') && jQuery('#radioButtonValue_sammen').val() == 'yes') {
-            jQuery('#path_geo').val(UKMresources.arrangement.getPathFromForm(checkboxSelector)).change();
+            var value = UKMresources.arrangement.getPathFromForm(checkboxSelector);
+            
+            // Sjekker URL fordi det WP aksepterer URL mindre enn 100
+            if(value.length > 40) {
+                value = value.slice(0, 40);
+            }
+            jQuery('#path_geo').val(value).change();
         }
         // Første arrangement i kommunen overtar kommunens path
         else {
+            var value = UKMresources.arrangement.getPathFromForm(false, '#omrade_navn');
+            
+            // Sjekker URL fordi det WP aksepterer URL mindre enn 100
+            if(value.length > 40) {
+                value = value.slice(0, 40);
+            }
             jQuery('#path_geo').val(UKMresources.arrangement.getPathFromForm(false, '#omrade_navn')).change();
             //jQuery('#path-infos').slideUp(); // Skjul path - 
         }
         // Alle andre får arrangementsnavn
         
-        jQuery('#path_event').val(UKMresources.arrangement.getUrlFromName(jQuery('#arrangement_navn').val()));
+        // Sjekker arrangement navn på URL fordi det WP aksepterer URL mindre enn 100
+        arrangementNavn = UKMresources.arrangement.getUrlFromName(jQuery('#arrangement_navn').val());
+        if(arrangementNavn.length > 40) {
+            arrangementNavn = arrangementNavn.slice(0, 40);
+        }
+        jQuery('#path_event').val(arrangementNavn);
         
         jQuery('#path_event').trigger('focusout');
     });


### PR DESCRIPTION
URL length var ikke begrenset og når man legger til flere kommuner og laaang navn, da kræser Wordpress. Dessuten har vi 100 chars på database for URL. Nå er det begrenset til 40 chars for kommuner og 40 for arrangement navn som er lik 80 chars maks.